### PR TITLE
Fix import error

### DIFF
--- a/backend/source/archive/models/google_takeout.py
+++ b/backend/source/archive/models/google_takeout.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from collections import Generator
 import glob
 from datetime import datetime
 from pathlib import Path


### PR DESCRIPTION
Resolves #13. One more error when setting up. Old version of collections Generator cannot be imported