### PR TITLE
Frontend: Move 'today' button

### DIFF
--- a/frontend/source/js/components/timeline-nav.js
+++ b/frontend/source/js/components/timeline-nav.js
@@ -53,11 +53,11 @@ export default Vue.component('timeline-nav', {
       <button class="minus-1-week week button" @click="moveTimelineDate('weeks', -1)">-1W</button>
       <button class="minus-1-day day button" @click="moveTimelineDate('days', -1)">-1D</button>
       <input class="input" type="date" v-model="timelineDateIso" :max="today.format('YYYY-MM-DD')">
-      <button class="today button" :disabled="!showTomorrow" @click="pickTimelineDate(today)">Today</button>
       <button class="plus-1-day day button" :disabled="!showTomorrow" @click="moveTimelineDate('days', 1)">+1D</button>
       <button class="plus-1-week week button" :disabled="!showNextWeek" @click="moveTimelineDate('weeks', 1)">+1W</button>
       <button class="plus-1-month month button" :disabled="!showNextMonth" @click="moveTimelineDate('months', 1)">+1M</button>
       <button class="plus-1-year year button" :disabled="!showNextYear" @click="moveTimelineDate('years', 1)">+1Y</button>
+      <button class="today button" :disabled="!showTomorrow" @click="pickTimelineDate(today)">Today</button>
     </nav>
   `
 });


### PR DESCRIPTION
I find it awkward to navigate between days with the "today" button where it is - next to the current date. Suggestion to move it to the side