### PR TITLE
Add 'key' field to sources

### DIFF
--- a/backend/source/backup/serializers.py
+++ b/backend/source/backup/serializers.py
@@ -7,8 +7,11 @@ from .models.rss import RssSource
 from .models.rsync import RsyncSource, RsyncDestination
 from .models.twitter import TwitterSource
 
+class BaseSourceSerializer(serializers.HyperlinkedModelSerializer):
+    key = serializers.CharField()
 
-class RsyncSourceSerializer(serializers.HyperlinkedModelSerializer):
+
+class RsyncSourceSerializer(BaseSourceSerializer):
     password = serializers.CharField(write_only=True, style={'input_type': 'password'})
 
     class Meta:
@@ -16,7 +19,7 @@ class RsyncSourceSerializer(serializers.HyperlinkedModelSerializer):
         fields = '__all__'
 
 
-class RsyncDestinationSerializer(serializers.HyperlinkedModelSerializer):
+class RsyncDestinationSerializer(BaseSourceSerializer):
     password = serializers.CharField(write_only=True, style={'input_type': 'password'})
 
     class Meta:
@@ -24,31 +27,31 @@ class RsyncDestinationSerializer(serializers.HyperlinkedModelSerializer):
         fields = '__all__'
 
 
-class TwitterSourceSerializer(serializers.HyperlinkedModelSerializer):
+class TwitterSourceSerializer(BaseSourceSerializer):
     class Meta:
         model = TwitterSource
         fields = '__all__'
 
 
-class RedditSourceSerializer(serializers.HyperlinkedModelSerializer):
+class RedditSourceSerializer(BaseSourceSerializer):
     class Meta:
         model = RedditSource
         fields = '__all__'
 
 
-class HackerNewsSourceSerializer(serializers.HyperlinkedModelSerializer):
+class HackerNewsSourceSerializer(BaseSourceSerializer):
     class Meta:
         model = HackerNewsSource
         fields = '__all__'
 
 
-class RssSourceSerializer(serializers.HyperlinkedModelSerializer):
+class RssSourceSerializer(BaseSourceSerializer):
     class Meta:
         model = RssSource
         fields = '__all__'
 
 
-class FileSystemSourceSerializer(serializers.HyperlinkedModelSerializer):
+class FileSystemSourceSerializer(BaseSourceSerializer):
     class Meta:
         model = FileSystemSource
         fields = '__all__'


### PR DESCRIPTION
Resolves #19 
Browsing `/api/source/xxx` there is a lack of `key` field. Alter the serializers to account for this field, and write it to the model