### PR TITLE
 gpx parse fix

### DIFF
--- a/backend/source/archive/models/gpx.py
+++ b/backend/source/archive/models/gpx.py
@@ -32,7 +32,7 @@ class GpxArchive(FileArchive):
 
     def extract_entries(self) -> Generator[Entry, None, None]:
         for gpx_file in self.get_archive_files():
-            gpx = gpxpy.parse(gpx_file)
+            gpx = gpxpy.parse(open(gpx_file, 'r'))
             for track in gpx.tracks:
                 for segment in track.segments:
                     for point in segment.points:


### PR DESCRIPTION
Importing a gpx file does not work unless the file has a `read` attribute when using `parse`

----
As a side not I am using Owntracks in its own instance, exporting using `ocat`, and importing into this timeline. One issue is that owntracks exports .gpx files with single quotes `'` in the schema, while gpxpy expects the file to have double quotes `"`.  See         https://github.com/tkrajina/gpxpy/blob/cb243b22841bd2ce9e603fe3a96672fc75edecf2/gpxpy/parser.py#L105. I'm not if one of the two repos isn't following the schema properly. It means I need to manually adjust single quotes to double during the export/import process